### PR TITLE
防止属性名和GridLayout冲突

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ FluidLayout是一个Android平台上的开源控件，提供了流布局的布�
 
 `在 Gradle 项目中添加依赖：`
 ```
-compile 'com.fynn.fluidlayout:fluidlayout:1.0'
+compile 'com.fynn.fluidlayout:fluidlayout:1.1'
 ```
 
 `支持的布局属性：`
 
-> gravity="center" 单行垂直居中对齐
+> fl_gravity="center" 单行垂直居中对齐
 
-> gravity="bottom" 单行底部对其
+> fl_gravity="bottom" 单行底部对其
 
-> gravity="top" 单行顶部对其
+> fl_gravity="top" 单行顶部对其
 
 该控件支持 `ScrollView` 嵌套。
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,18 +2,20 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/fluidlayout/build.gradle
+++ b/fluidlayout/build.gradle
@@ -9,12 +9,11 @@ group = "com.fynn.fluidlayout"
 version = "1.1"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 20160521
         versionName "1.0"
     }

--- a/fluidlayout/build.gradle
+++ b/fluidlayout/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.jfrog.bintray'
 def siteUrl = 'https://github.com/ifynn/FluidLayout'
 def gitUrl = 'https://github.com/ifynn/FluidLayout.git'
 group = "com.fynn.fluidlayout"
-version = "1.0"
+version = "1.1"
 
 android {
     compileSdkVersion 23

--- a/fluidlayout/src/main/java/com/fynn/fluidlayout/FluidLayout.java
+++ b/fluidlayout/src/main/java/com/fynn/fluidlayout/FluidLayout.java
@@ -41,7 +41,7 @@ public class FluidLayout extends ViewGroup {
         super(context, attrs, defStyleAttr);
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.FluidLayout);
-        int index = a.getInt(R.styleable.FluidLayout_gravity, -1);
+        int index = a.getInt(R.styleable.FluidLayout_fl_gravity, -1);
         if (index >= 0) {
             setGravity(index);
         }
@@ -216,7 +216,7 @@ public class FluidLayout extends ViewGroup {
 
             TypedArray a =
                     c.obtainStyledAttributes(attrs, R.styleable.FluidLayout_Layout);
-            gravity = a.getInt(R.styleable.FluidLayout_Layout_layout_gravity, -1);
+            gravity = a.getInt(R.styleable.FluidLayout_Layout_layout_fl_gravity, -1);
             a.recycle();
         }
 

--- a/fluidlayout/src/main/res/values/attrs.xml
+++ b/fluidlayout/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="FluidLayout">
-        <attr name="gravity" >
+        <attr name="fl_gravity" >
             <flag name="top" value="0x30" />
             <flag name="bottom" value="0x50" />
             <flag name="center" value="0x11" />
@@ -9,7 +9,7 @@
     </declare-styleable>
 
     <declare-styleable name="FluidLayout_Layout">
-        <attr name="layout_gravity">
+        <attr name="layout_fl_gravity">
             <flag name="top" value="0x30" />
             <flag name="bottom" value="0x50" />
             <flag name="center" value="0x11" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "com.fynn.fluidlayout.sample"
-        minSdkVersion 9
-        targetSdkVersion 23
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -20,8 +19,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile project(':fluidlayout')
-    compile 'com.android.support:design:23.2.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation project(':fluidlayout')
+    implementation 'com.android.support:design:26.1.0'
 }


### PR DESCRIPTION
3.2上默认开启的AAPT2不支持重复的属性名

参见：https://github.com/akashandroid90/ImageLetterIcon/issues/7